### PR TITLE
dpar-fifu-pmi: init at unstable-20200916

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
 { pkgs ? import (import ./nix/sources.nix).nixpkgs {} }:
 
 rec {
-  dpar = pkgs.callPackage pkgs/dpar {
+  inherit (pkgs.callPackage pkgs/dpar {
     inherit libtensorflow;
-  };
+  }) dpar dpar-fifu-pmi;
 
   dpar_models = pkgs.callPackage pkgs/dpar_models {
     inherit dpar;

--- a/pkgs/dpar/default.nix
+++ b/pkgs/dpar/default.nix
@@ -8,32 +8,34 @@
 , openssl
 }:
 
-rustPlatform.buildRustPackage rec {
-  pname = "dpar";
-  version = "0.2.0";
+let
+  generic = import ./generic.nix {
+    inherit lib rustPlatform pkg-config libtensorflow openssl;
+  };
+in {
+  dpar = generic rec {
+    version = "0.2.0";
 
-  src = fetchFromGitHub {
-    owner = "danieldk";
-    repo = "dpar";
-    rev = version;
-    sha256 = "02zw4dw8nanvbc2sngv5rwqszc3rp0lgr2gjrr6ag9p4d82s6jny";
+    src = fetchFromGitHub {
+      owner = "danieldk";
+      repo = "dpar";
+      rev = version;
+      sha256 = "02zw4dw8nanvbc2sngv5rwqszc3rp0lgr2gjrr6ag9p4d82s6jny";
+    };
+
+    cargoSha256 = "11zmjmkvblar094nn57cpxr1zyx07a15cyxbi7rq65hmavhbkmr2";
   };
 
-  cargoSha256 = "11zmjmkvblar094nn57cpxr1zyx07a15cyxbi7rq65hmavhbkmr2";
+  dpar-fifu-pmi = generic rec {
+    version = "unstable-20200916";
 
-  nativeBuildInputs = [ pkg-config ];
+    src = fetchFromGitHub {
+      owner = "DiveFish";
+      repo = "assoc-parsing";
+      rev = "8312f0f6b5711776ea2f41a3f8643de2e9583665";
+      sha256 = "0bm9qc6bssm1kd95i7n2b9i7z22lcy0h6hxxr4hb3wxmphaypxiz";
+    };
 
-  buildInputs = [
-    libtensorflow
-    openssl
-  ];
-
-  OPENSSL_NO_VENDOR = 1;
-
-  meta = with lib; {
-    description = "Neural transition-based dependency parser";
-    license = licenses.asl20;
-    maintainers = with maintainers; [ danieldk ];
-    platforms = platforms.unix;
+    cargoSha256 = "1vr8v64h0k9vykjv0kvsy849gsgfkjw5s7njizn437v5cz4z312n";
   };
 }

--- a/pkgs/dpar/generic.nix
+++ b/pkgs/dpar/generic.nix
@@ -1,0 +1,40 @@
+{ lib
+, rustPlatform
+
+, pkg-config
+
+, libtensorflow
+, openssl
+}:
+
+{ # Source of the dpar to build.
+  src
+
+  # Vendored dependencies hash.
+, cargoSha256
+
+  # Version
+, version
+}:
+
+rustPlatform.buildRustPackage rec {
+  inherit cargoSha256 src version;
+
+  pname = "dpar";
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    libtensorflow
+    openssl
+  ];
+
+  OPENSSL_NO_VENDOR = 1;
+
+  meta = with lib; {
+    description = "Neural transition-based dependency parser";
+    license = licenses.asl20;
+    maintainers = with maintainers; [ danieldk ];
+    platforms = platforms.unix;
+  };
+}


### PR DESCRIPTION
Factor out the shared parts of dpar and dpar-fifu-pmi to generix.nix.